### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "html"
+run = "index.html"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Funny-Little-Website
 A website that starts dinga, dinga, dinga.
+[![Run on Repl.it](https://repl.it/badge/github/plezploz/Funny-Little-Website)](https://repl.it/github/plezploz/Funny-Little-Website)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@brightgao/Funny-Little-Website).